### PR TITLE
Use `expect_no_message()` over `expect_silent()`

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -18,7 +18,7 @@ Imports:
     R.matlab
 Suggests:
     covr,
-    testthat,
+    testthat (>= 3.1.6),
     knitr,
     rmarkdown
 License: GPL-3 | file LICENSE

--- a/tests/testthat/test-load-data.R
+++ b/tests/testthat/test-load-data.R
@@ -21,7 +21,7 @@ test_that("test that it is possible to load multiple LANS summaries", {
     load_LANS_summary (analysis = c("analysis1", "analysis2", "analysis3"), 
                        base_dir = folder, load_zstacks = FALSE), 
     ".*read successfully.*Z-stacks were not loaded")
-  expect_silent(
+  expect_no_message(
     data <- load_LANS_summary (analysis = c("analysis1", "analysis2", "analysis3"), 
                                base_dir = folder, load_zstacks = FALSE, quiet = TRUE))
   
@@ -40,7 +40,7 @@ test_that("test that it is possible to load multiple LANS summaries", {
     load_LANS_summary (analysis = c("analysis1", "analysis2", "analysis3"), 
                        base_dir = folder, load_zstacks = TRUE), 
     ".*read successfully.*Z-stacks were loaded")
-  expect_silent(
+  expect_no_message(
     data <- load_LANS_summary (analysis = c("analysis1", "analysis2", "analysis3"), 
                                base_dir = folder, load_zstacks = TRUE, quiet = TRUE))
   
@@ -55,7 +55,7 @@ test_that("test that it is possible to load multiple LANS summaries", {
                  "17.38", "192.93", "0.83", "353", "2.45"))
   
   # additional information
-  expect_silent(
+  expect_no_message(
     data <- load_LANS_summary (analysis = c("analysis1", "analysis2", "analysis3"), 
                                information = c("run1", "run2", "run3"),
                                date = as.Date(c("2015-01-01", "2016-02-25", "2017-03-04")),
@@ -78,8 +78,8 @@ test_that("test that it is possible to load LANS maps", {
   
   expect_true(file.exists(folder <- system.file("extdata", "nanosims_data", package = "lans2r")))
   
-  expect_silent(maps <- load_LANS_maps (analysis = c("analysis1", "analysis2", "analysis3"), 
-                                        base_dir = folder, quiet = TRUE))
+  expect_no_message(maps <- load_LANS_maps (analysis = c("analysis1", "analysis2", "analysis3"), 
+                                            base_dir = folder, quiet = TRUE))
   
   # check data
   expect_equal(nrow(maps), as.integer(256^2 * 4 * 3)) 


### PR DESCRIPTION
This PR makes your package compatible with the next version of dplyr:

The join functions in dplyr (like `left_join()`) now return a warning by default when a row in `x` matches _multiple_ rows in `y`. While this is typical SQL behavior, it is often unexpected during data analysis (many people don't even know it is possible), so we've decided to make this a warning. In dplyr 1.1.0, you silence this warning with `multiple = "all"`. In the meantime, we need to work around broken tests of yours that were expecting no output. I've done that by swapping `expect_silent()` for `expect_no_message()`, which looks to be what you are really trying to avoid.

We plan to submit dplyr 1.1.0 on January 27th.

This should be compatible with both dev and CRAN dplyr. It would help us out if you could go ahead and send a patch version of your package to CRAN ahead of time! Thanks!